### PR TITLE
fix(monitoring): use new query parameter format for resource status l…

### DIFF
--- a/servicegroup-monitoring/src/index.php
+++ b/servicegroup-monitoring/src/index.php
@@ -174,10 +174,22 @@ $buildServicegroupUri = function (
             'filter' => json_encode(
                 [
                     'criterias' => [
-                        'serviceGroups' => $servicegroups,
-                        'resourceTypes' => $types,
-                        'statuses' => $statuses,
-                        'search' => $search,
+                        [
+                            'name' => 'service_groups',
+                            'value' => $servicegroups
+                        ],
+                        [
+                            'name' => 'resource_types',
+                            'value' => $types
+                        ],
+                        [
+                            'name' => 'statuses',
+                            'value' => $statuses
+                        ],
+                        [
+                            'name' => 'search',
+                            'value' => $search
+                        ]
                     ],
                 ]
             ),


### PR DESCRIPTION
…inks

This PR intends to use the query parameter format for resource status redirections

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add the servicegroup monitoring widget
- Click on all the links that redirects to the Resource Status page and check the consistency of the filter used and the data displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
